### PR TITLE
fix: use BuildKit secret mount for GH_TOKEN in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 ARG BUILD_IMAGE=node:20-bullseye
 ARG RUN_IMAGE=gcr.io/distroless/nodejs20-debian11:nonroot
@@ -11,9 +12,8 @@ COPY ./src ./src
 COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
 
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
 RUN npm run build
 
 FROM ${BUILD_IMAGE} AS dep-resolver
@@ -22,8 +22,7 @@ LABEL stage=pre-prod
 
 COPY package*.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
-RUN npm ci --omit=dev --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --omit=dev --ignore-scripts
 RUN mkdir uploads
 
 FROM ${RUN_IMAGE} AS run-env


### PR DESCRIPTION
## Problem

The Docker build workflow passes `GH_TOKEN` as a BuildKit secret (`--secret id=GH_TOKEN,...`), but the Dockerfile was still using `ARG GH_TOKEN` to receive it as a build argument. This caused `npm ci` to fail with no authentication, breaking the `dockerhub-image-build-rc.yml` run.

## Fix

- Add `# syntax=docker/dockerfile:1` header (required for BuildKit secret mount syntax)
- Remove `ARG GH_TOKEN` from `builder` and `dep-resolver` stages
- Replace `RUN npm ci ...` with `RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci ...` in both stages

This matches the pattern used across all other service repos (e.g. `typology-processor`). The token is now available only for the duration of the `RUN` instruction and is never baked into any image layer.