### PR TITLE
feat: add authenticated execute support with tenant propagation

### DIFF
--- a/__tests__/unit/auth-controller.test.ts
+++ b/__tests__/unit/auth-controller.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { extractTenant } from '@tazama-lf/auth-lib';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+jest.mock('@tazama-lf/frms-coe-lib/lib/config/processor.config', () => ({
+  validateProcessorConfig: jest.fn().mockReturnValue({
+    functionName: 'test-ed',
+    nodeEnv: 'test',
+    maxCPU: 1,
+  }),
+}));
+
+jest.mock('@tazama-lf/frms-coe-lib/lib/services/apm', () => ({
+  Apm: jest.fn().mockReturnValue({
+    startSpan: jest.fn(),
+    getCurrentTraceparent: jest.fn().mockReturnValue(''),
+  }),
+}));
+
+jest.mock('@tazama-lf/frms-coe-lib/lib/services/dbManager', () => ({
+  CreateStorageManager: jest.fn().mockReturnValue({
+    db: {
+      set: jest.fn(),
+      quit: jest.fn(),
+      isReadyCheck: jest.fn().mockReturnValue({ nodeEnv: 'test' }),
+    },
+    config: {
+      redisConfig: { distributedCacheTTL: 300 },
+    },
+  }),
+}));
+
+jest.mock('@tazama-lf/auth-lib', () => ({
+  extractTenant: jest.fn(),
+}));
+
+const mockedExtractTenant = jest.mocked(extractTenant);
+
+import { handleExecute } from '../../src/app.controller';
+import * as FileService from '../../src/services/file.service';
+import { configuration } from '../../src';
+import { GetPain001FromLine } from '../../src/services/message.generation.service';
+import { Fields } from '../../src/utils/transaction.enum';
+
+const makeReply = (): FastifyReply => {
+  const reply: any = {};
+  reply.code = jest.fn().mockReturnValue(reply);
+  reply.send = jest.fn().mockReturnValue(reply);
+  return reply as FastifyReply;
+};
+
+const makeRequest = (authHeader?: string): FastifyRequest =>
+  ({
+    headers: { authorization: authHeader },
+    body: { evaluate: false },
+  }) as unknown as FastifyRequest;
+
+const makeColumns = (): string[] => {
+  const cols = new Array(14).fill('');
+  cols[Fields.PROCESSING_DATE_TIME] = new Date().toISOString();
+  cols[Fields.MESSAGE_ID] = 'msg-001';
+  cols[Fields.TRANSACTION_TYPE] = 'TRANSFER';
+  cols[Fields.PAYMENT_CURRENCY_CODE] = 'USD';
+  cols[Fields.TOTAL_PAYMENT_AMOUNT] = '100.00';
+  cols[Fields.SENDER_ID] = 'sender-001';
+  cols[Fields.SENDER_NAME] = 'Test Sender';
+  cols[Fields.RECEIVER_ID] = 'receiver-001';
+  cols[Fields.RECEIVER_NAME] = 'Test Receiver';
+  cols[Fields.SENDER_AGENT_SPID] = 'SPID001';
+  cols[Fields.RECEIVER_AGENT_SPID] = 'SPID002';
+  cols[Fields.SENDER_ACCOUNT] = 'acc-001';
+  cols[Fields.RECEIVER_ACCOUNT] = 'acc-002';
+  cols[Fields.REPORTING_CODE] = 'RC001';
+  return cols;
+};
+
+describe('handleExecute - authentication', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when AUTHENTICATED is true', () => {
+    beforeAll(() => {
+      configuration.AUTHENTICATED = true;
+    });
+
+    afterAll(() => {
+      configuration.AUTHENTICATED = false;
+    });
+
+    it('should return 401 when extractTenant fails', async () => {
+      mockedExtractTenant.mockReturnValue({ success: false });
+      const req = makeRequest();
+      const reply = makeReply();
+
+      await handleExecute(req, reply);
+
+      expect(mockedExtractTenant).toHaveBeenCalledWith(true, undefined);
+      expect(reply.code).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('should return 401 when extractTenant succeeds but returns no tenantId', async () => {
+      mockedExtractTenant.mockReturnValue({ success: true });
+      const req = makeRequest('Bearer token');
+      const reply = makeReply();
+
+      await handleExecute(req, reply);
+
+      expect(reply.code).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('should call SendLineMessages with tenantId and authHeader on success', async () => {
+      mockedExtractTenant.mockReturnValue({ success: true, tenantId: 'test-tenant' });
+      const sendSpy = jest.spyOn(FileService, 'SendLineMessages').mockResolvedValue('done');
+      const req = makeRequest('Bearer valid-token');
+      const reply = makeReply();
+
+      await handleExecute(req, reply);
+
+      expect(sendSpy).toHaveBeenCalledWith({ evaluate: false }, 'test-tenant', 'Bearer valid-token');
+      expect(reply.send).toHaveBeenCalledWith('done');
+    });
+  });
+
+  describe('when AUTHENTICATED is false', () => {
+    beforeAll(() => {
+      configuration.AUTHENTICATED = false;
+    });
+
+    it('should call SendLineMessages with DEFAULT tenantId when not authenticated', async () => {
+      mockedExtractTenant.mockReturnValue({ success: true, tenantId: 'DEFAULT' });
+      const sendSpy = jest.spyOn(FileService, 'SendLineMessages').mockResolvedValue('done');
+      const req = makeRequest();
+      const reply = makeReply();
+
+      await handleExecute(req, reply);
+
+      expect(sendSpy).toHaveBeenCalledWith({ evaluate: false }, 'DEFAULT', undefined);
+      expect(reply.send).toHaveBeenCalledWith('done');
+    });
+  });
+});
+
+describe('GetPain001FromLine - tenantId propagation', () => {
+  it('should set TenantId from the tenantId parameter', () => {
+    const columns = makeColumns();
+    const result = GetPain001FromLine(columns, 'my-tenant');
+    expect(result.TenantId).toBe('my-tenant');
+  });
+
+  it('should use DEFAULT tenantId when passed DEFAULT', () => {
+    const columns = makeColumns();
+    const result = GetPain001FromLine(columns, 'DEFAULT');
+    expect(result.TenantId).toBe('DEFAULT');
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -26,7 +26,7 @@ const config: Config.InitialOptions = {
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   //collectCoverageFrom: ['src/app.controller.ts'],
-  collectCoverageFrom: ['_src/services/save.transactions.service.ts'],
+  collectCoverageFrom: ['src/**/*.ts'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: '<rootDir>/coverage/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/multipart": "^9.2.1",
         "@fastify/swagger": "^9.5.1",
         "@fastify/swagger-ui": "^5.2.3",
+        "@tazama-lf/auth-lib": "4.0.0-rc.4",
         "@tazama-lf/frms-coe-lib": "8.0.0-rc.5",
         "axios": "^1.10.0",
         "fastify": "^5.4.0",
@@ -2712,6 +2713,18 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tazama-lf/auth-lib": {
+      "version": "4.0.0-rc.4",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/auth-lib/4.0.0-rc.4/bd1087315ca3f9937e3c8fcaec0b194274620a53",
+      "integrity": "sha512-NOf55XmNZPqQT819Y+Difh4QJgsEmLSBCt6ba3lBcbGRRIlX4wERi7mJ9uiL5AvCUiEcog1Sl4AggyGpZ2dSRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=22.17"
+      }
+    },
     "node_modules/@tazama-lf/frms-coe-lib": {
       "version": "8.0.0-rc.5",
       "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.5/ca83d3a70118dc6009a7adc3e40c2c8028b3591f",
@@ -4187,6 +4200,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5017,6 +5036,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/elastic-apm-node": {
       "version": "4.15.0",
@@ -8569,6 +8597,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8783,10 +8854,46 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -8801,6 +8908,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@fastify/multipart": "^9.2.1",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.3",
+    "@tazama-lf/auth-lib": "4.0.0-rc.4",
     "@tazama-lf/frms-coe-lib": "8.0.0-rc.5",
     "axios": "^1.10.0",
     "fastify": "^5.4.0",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,17 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import { extractTenant } from '@tazama-lf/auth-lib';
 import fs from 'node:fs';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
-import { loggerService } from './';
+import { configuration, loggerService } from './';
 import { SendLineMessages } from './services/file.service';
 import type { ExecuteReqBody } from './utils/interface.request';
 
 export const handleExecute = async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
   loggerService.log('Start - Handle execute request');
   try {
-    reply.send(await SendLineMessages(req?.body as ExecuteReqBody));
+    const tenantResponse = extractTenant(configuration.AUTHENTICATED, req.headers.authorization);
+    if (!tenantResponse.success || !tenantResponse.tenantId) {
+      loggerService.error('Tenant validation failed: No tenantId found in token', 'handleExecute()');
+      reply.code(401).send({ error: 'Unauthorized' });
+      return;
+    }
+    reply.send(await SendLineMessages(req?.body as ExecuteReqBody, tenantResponse.tenantId, req.headers.authorization));
   } catch (err) {
     const failMessage = 'Failed to process execution request.';
     loggerService.error(failMessage, err as Error, 'ApplicationService');

--- a/src/clients/fastify.ts
+++ b/src/clients/fastify.ts
@@ -44,7 +44,7 @@ export default async function initializeFastifyClient(): Promise<FastifyInstance
   });
   await fastify.register(fastifyMultipart, {
     limits: {
-      fileSize: (configuration.MAX_FILE_SIZE || 100) * 1024 * 1024, // Convert MB to bytes
+      fileSize: (configuration.MAX_FILE_SIZE ?? 100) * 1024 * 1024, // Convert MB to bytes
       files: 1, // Limit to 1 file
       parts: 1, // File only, no other form fields
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,6 @@ export const additionalEnvironmentVariables: AdditionalConfig[] = [
   {
     name: 'DELIMITER',
     type: 'string',
-    optional: true,
   },
   {
     name: 'TMS_ENDPOINT',
@@ -38,7 +37,7 @@ export interface ExtendedConfig {
   QUOTING: boolean;
   TMS_ENDPOINT: string;
   MAX_FILE_SIZE?: number;
-  DELIMITER?: string;
+  DELIMITER: string;
   AUTHENTICATED: boolean;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,6 @@ export const additionalEnvironmentVariables: AdditionalConfig[] = [
   {
     name: 'AUTHENTICATED',
     type: 'boolean',
-    optional: true,
   },
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,11 @@ export const additionalEnvironmentVariables: AdditionalConfig[] = [
     type: 'number',
     optional: true,
   },
+  {
+    name: 'AUTHENTICATED',
+    type: 'boolean',
+    optional: true,
+  },
 ];
 
 export interface ExtendedConfig {
@@ -35,6 +40,7 @@ export interface ExtendedConfig {
   TMS_ENDPOINT: string;
   MAX_FILE_SIZE: number;
   DELIMITER: string;
+  AUTHENTICATED: boolean;
 }
 
 type Databases = Required<Pick<ManagerConfig, 'eventHistory' | 'redisConfig' | 'rawHistory'>>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,8 +37,8 @@ export interface ExtendedConfig {
   PORT: number;
   QUOTING: boolean;
   TMS_ENDPOINT: string;
-  MAX_FILE_SIZE: number;
-  DELIMITER: string;
+  MAX_FILE_SIZE?: number;
+  DELIMITER?: string;
   AUTHENTICATED: boolean;
 }
 

--- a/src/services/file.service.ts
+++ b/src/services/file.service.ts
@@ -46,7 +46,7 @@ export const SendLineMessages = async (requestBody: ExecuteReqBody, tenantId: st
     }
 
     // Each line in input.txt will be successively available here as `line`.
-    const columns = line.split(configuration.DELIMITER ?? '|');
+    const columns = line.split(configuration.DELIMITER);
     if (!new Date(columns[Fields.PROCESSING_DATE_TIME]).getTime()) {
       if (index === 1) {
         continue;

--- a/src/services/file.service.ts
+++ b/src/services/file.service.ts
@@ -7,7 +7,7 @@ import { sendPacs002Transaction, sendPrepareTransaction } from '../utils/helper.
 import type { ExecuteReqBody } from '../utils/interface.request';
 import { Fields } from '../utils/transaction.enum';
 
-export const SendLineMessages = async (requestBody: ExecuteReqBody): Promise<string> => {
+export const SendLineMessages = async (requestBody: ExecuteReqBody, tenantId: string, authHeader?: string): Promise<string> => {
   // Create batch metadata from file information
   const batchFilePath = './build/uploads/batch.txt';
   let batchMetadata: { timestamp?: string; fileName?: string; fileSize?: number } | undefined;
@@ -57,10 +57,10 @@ export const SendLineMessages = async (requestBody: ExecuteReqBody): Promise<str
     }
 
     if (requestBody.evaluate) {
-      await sendPacs002Transaction(columns);
+      await sendPacs002Transaction(columns, authHeader);
       processedCount++;
     } else {
-      const { pacs008Result, pain001Result, pain013Result } = await sendPrepareTransaction(columns, batchMetadata);
+      const { pacs008Result, pain001Result, pain013Result } = await sendPrepareTransaction(columns, tenantId, batchMetadata);
 
       if ((!requestBody.evaluate && configuration.QUOTING && !pacs008Result) || !pain001Result || !pain013Result) {
         loggerService.error(

--- a/src/services/message.generation.service.ts
+++ b/src/services/message.generation.service.ts
@@ -10,7 +10,7 @@ function adjustInMilliseconds(isoDateString: string, milliseconds: number): stri
   return date.toISOString();
 }
 
-export const GetPain001FromLine = (columns: string[]): Pain001 => {
+export const GetPain001FromLine = (columns: string[], tenantId: string): Pain001 => {
   const end2endID = columns[Fields.MESSAGE_ID];
   const pain001: Pain001 = {
     CstmrCdtTrfInitn: {
@@ -219,7 +219,7 @@ export const GetPain001FromLine = (columns: string[]): Pain001 => {
       },
     },
     TxTp: 'pain.001.001.11',
-    TenantId: 'DEFAULT',
+    TenantId: tenantId,
   };
 
   return pain001;

--- a/src/utils/execute.https.ts
+++ b/src/utils/execute.https.ts
@@ -4,10 +4,11 @@ import apm from 'elastic-apm-node';
 import * as util from 'node:util';
 import { loggerService } from '..';
 
-export const executePost = async (endpoint: string, request: unknown): Promise<boolean> => {
+export const executePost = async (endpoint: string, request: unknown, authHeader?: string): Promise<boolean> => {
   const span = apm.startSpan(`POST ${endpoint}`);
   try {
-    const eventDirectorRes = await axios.post(endpoint, request);
+    const headers = authHeader ? { Authorization: authHeader } : undefined;
+    const eventDirectorRes = await axios.post(endpoint, request, { headers });
 
     if (eventDirectorRes.status !== 200) {
       loggerService.error(`Transaction-Monitoring-Service Response StatusCode != 200, request:\r\n${util.inspect(request)}`);

--- a/src/utils/helper.functions.ts
+++ b/src/utils/helper.functions.ts
@@ -6,22 +6,23 @@ import { GetPacs002, GetPacs008, GetPain001FromLine, GetPain013 } from '../servi
 import { handleTransaction } from '../services/save.transactions.service';
 import { executePost } from '../utils/execute.https';
 
-export const sendPacs002Transaction = async (columns: string[]): Promise<boolean> => {
+export const sendPacs002Transaction = async (columns: string[], authHeader?: string): Promise<boolean> => {
   loggerService.trace('Sending Pacs002 message...');
   const currentPacs002 = GetPacs002(columns);
   loggerService.trace(`${util.inspect(currentPacs002.FIToFIPmtSts.GrpHdr.MsgId)} - Submitted`);
-  return await executePost(`${configuration.TMS_ENDPOINT}/v1/evaluate/iso20022/pacs.002.001.12`, currentPacs002);
+  return await executePost(`${configuration.TMS_ENDPOINT}/v1/evaluate/iso20022/pacs.002.001.12`, currentPacs002, authHeader);
 };
 
 export const sendPrepareTransaction = async (
   columns: string[],
+  tenantId: string,
   batchMetadata?: { timestamp?: string; fileName?: string; fileSize?: number },
 ): Promise<{
   pain001Result: Pain001 | boolean;
   pain013Result: Pain013 | boolean;
   pacs008Result: Pacs008 | boolean;
 }> => {
-  const currentPain001 = GetPain001FromLine(columns);
+  const currentPain001 = GetPain001FromLine(columns, tenantId);
   const currentPacs008 = GetPacs008(currentPain001);
 
   let pain001Result: Pain001 | boolean = true;


### PR DESCRIPTION
## Summary

Fixes two blockers that prevented batch-ppa from working correctly in an authenticated Tazama deployment:

### Problem 1 - Evaluate mode: 401 from TMS

`POST /v1/executebatch { "evaluate": true }` proxies pacs.002 messages to TMS. TMS runs with `AUTHENTICATED=true` and validates the caller's JWT. The previous implementation sent the axios POST with no `Authorization` header, so TMS rejected every request with 401.

### Problem 2 - Prepare mode: wrong tenantId in persisted data

`TenantId` was hardcoded to `'DEFAULT'` in `GetPain001FromLine`. In a multi-tenant or non-default-tenant deployment this corrupts all persisted pain.001/pain.013/pacs.008 records.

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `@tazama-lf/auth-lib@4.0.0-rc.4` |
| `src/config.ts` | Add `AUTHENTICATED` (boolean, optional) to config and `ExtendedConfig` |
| `src/app.controller.ts` | Call `extractTenant` on entry; return 401 if tenant extraction fails; pass `tenantId` and `authHeader` downstream |
| `src/services/file.service.ts` | Accept and propagate `tenantId` and `authHeader` |
| `src/utils/helper.functions.ts` | `sendPacs002Transaction` accepts `authHeader`; `sendPrepareTransaction` accepts `tenantId` |
| `src/utils/execute.https.ts` | Include `Authorization` header in axios call when `authHeader` is present |
| `src/services/message.generation.service.ts` | `GetPain001FromLine` accepts `tenantId` param; removes hardcoded `DEFAULT` |
| `jest.config.ts` | Fix `collectCoverageFrom` (was pointing at non-existent `_src/` path) |
| `__tests__/unit/auth-controller.test.ts` | New tests: 401 on failed extraction, 401 on missing tenantId, success path with correct params, tenantId propagation into pain.001 |

## Behaviour when AUTHENTICATED=false

`extractTenant(false)` returns `{ success: true, tenantId: 'DEFAULT' }` - no header required. The unauthenticated path is unchanged and continues to work correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication support with configurable mode; returns 401 Unauthorized when tenant validation fails
  * Supports both authenticated and non-authenticated operation modes

* **Dependencies**
  * Added new authentication library dependency

* **Tests**
  * Added comprehensive unit tests for authentication flows
  * Expanded test coverage configuration to include all source files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/batch-ppa/pull/227)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->