### PR TITLE
feat: add per-route claim validation to batch-ppa endpoints

### DIFF
--- a/src/auth/authHandler.ts
+++ b/src/auth/authHandler.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+import { validateTokenAndClaims } from '@tazama-lf/auth-lib';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { loggerService } from '..';
+
+export const tokenHandler =
+  (claim: string) =>
+  async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const logContext = 'tokenHandler()';
+    const authHeader = request.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ') || !claim) {
+      reply.code(401).send({ error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const [, token] = authHeader.split(' ');
+      const validated = validateTokenAndClaims(token, [claim]);
+      if (!validated[claim]) {
+        reply.code(401).send({ error: 'Unauthorized' });
+      }
+      loggerService.log('Authenticated', logContext);
+    } catch (error) {
+      const err = error as Error;
+      loggerService.error(`${err.name}: ${err.message}\n${err.stack}`, logContext);
+      reply.code(401).send({ error: 'Unauthorized' });
+    }
+  };

--- a/src/auth/authHandler.ts
+++ b/src/auth/authHandler.ts
@@ -18,6 +18,7 @@ export const tokenHandler =
       const validated = validateTokenAndClaims(token, [claim]);
       if (!validated[claim]) {
         reply.code(401).send({ error: 'Unauthorized' });
+        return;
       }
       loggerService.log('Authenticated', logContext);
     } catch (error) {

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,11 +5,16 @@ import { handleExecute, handleFileUpload } from './app.controller';
 import { handleHealthCheck } from './health.controller';
 import SetOptions from './utils/routes.options';
 
+const routePrivilege = {
+  executeBatch: 'POST_V1_EXECUTEBATCH',
+  uploadFile: 'POST_V1_UPLOADFILE',
+};
+
 function Routes(fastify: FastifyInstance): void {
   fastify.get('/', handleHealthCheck);
   fastify.get('/health', handleHealthCheck);
-  fastify.post('/v1/executebatch', SetOptions(handleExecute, 'executeBatchSchema'));
-  fastify.post('/v1/uploadfile', handleFileUpload);
+  fastify.post('/v1/executebatch', SetOptions(handleExecute, routePrivilege.executeBatch, 'executeBatchSchema'));
+  fastify.post('/v1/uploadfile', SetOptions(handleFileUpload, routePrivilege.uploadFile));
 }
 
 export default Routes;

--- a/src/utils/routes.options.ts
+++ b/src/utils/routes.options.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { FastifyReply, FastifyRequest, RouteHandlerMethod } from 'fastify';
 import type { FastifySchema } from 'fastify/types/schema';
+import { configuration } from '../';
+import { tokenHandler } from '../auth/authHandler';
 
 type preHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
 
@@ -21,10 +23,20 @@ const responseSchema = (schemaTransactionName: string): Record<string, unknown> 
 
 const SetOptions = (
   handler: RouteHandlerMethod,
-  schemaTransactionName: string,
-): { preHandler?: preHandler; handler: RouteHandlerMethod; schema: FastifySchema } => ({
-  handler,
-  schema: { body: { $ref: `${schemaTransactionName}#` }, response: responseSchema(schemaTransactionName) },
-});
+  claim: string,
+  schemaTransactionName?: string,
+): { preHandler?: preHandler[]; handler: RouteHandlerMethod; schema: FastifySchema } => {
+  const preHandlers: preHandler[] = configuration.AUTHENTICATED ? [tokenHandler(claim)] : [];
+
+  const schema: FastifySchema = schemaTransactionName
+    ? { body: { $ref: `${schemaTransactionName}#` }, response: responseSchema(schemaTransactionName) }
+    : {};
+
+  return {
+    preHandler: preHandlers.length > 0 ? preHandlers : undefined,
+    handler,
+    schema,
+  };
+};
 
 export default SetOptions;


### PR DESCRIPTION
## Summary

Both `POST /v1/executebatch` and `POST /v1/uploadfile` previously only verified that the JWT was valid and signed - they did not check whether the caller held a claim permitting access to those specific operations. Any valid Tazama JWT could call either endpoint regardless of the caller's intended permissions.

This PR adds per-route claim validation matching the TMS pattern.

## Changes

**`src/auth/authHandler.ts`** (new file)
- `tokenHandler(claim)` - validates the JWT carries the required claim using `validateTokenAndClaims` from `@tazama-lf/auth-lib`. Returns 401 if the claim is absent or the token is invalid/expired. Identical pattern to TMS.

**`src/utils/routes.options.ts`**
- `SetOptions` now accepts a `claim` parameter and an optional `schemaTransactionName`
- When `AUTHENTICATED=true`, injects `tokenHandler(claim)` as a Fastify pre-handler
- When `AUTHENTICATED=false`, no pre-handler is attached (existing behaviour preserved)

**`src/router.ts`**
- Defines `routePrivilege` map with two claims:
  - `POST_V1_EXECUTEBATCH` for `/v1/executebatch`
  - `POST_V1_UPLOADFILE` for `/v1/uploadfile`
- `/v1/uploadfile` now uses `SetOptions` (previously had no pre-handler at all)

## Security impact

With `AUTHENTICATED=true`, callers must hold both a valid JWT **and** the matching route claim. A JWT scoped for a different service will be rejected at the route gate before any controller logic runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bearer token authentication mechanism to secure API endpoints.
  * Implemented privilege-based access control for batch execution and file upload operations.
  * Routes now validate authentication claims and return authorization errors for invalid credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/batch-ppa/pull/228)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->